### PR TITLE
fix(config): “dfs.hosts” does not take IPs as an input

### DIFF
--- a/run_config.py
+++ b/run_config.py
@@ -36,7 +36,7 @@ def configure_hdfs_site():
     tree = et.parse(core_site_path)
     root = tree.getroot()
     root.append(create_property('dfs.blocksize', '268435456'))
-    root.append(create_property('dfs.hosts', '0.0.0.0'))
+    root.append(create_property('dfs.hosts', ''))
     root.append(create_property('dfs.namenode.handler.count', '100'))
     root.append(create_property('dfs.namenode.name.dir', '/hadoop/hdfs/data/dfs/namenode'))
     root.append(create_property('dfs.namenode.data.dir', '/hadoop/hdfs/data/dfs/datanode'))


### PR DESCRIPTION
https://hadoop.apache.org/docs/r2.4.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml

```
dfs.hosts |   | Names a file that contains a list of hosts that are permitted to connect to the namenode. The full pathname of the file must be specified. If the value is empty, all hosts are permitted.
```
