### PR TITLE
fix: update from 2-slim (buster) to 2-slim-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # To check running container: docker exec -it tube-spark /bin/bash
-FROM python:2-slim
+FROM python:2-slim-stretch
 
 ENV DEBIAN_FRONTEND=noninteractive \
     SPARK_VERSION="2.4.0" \


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
- Fixes the failed [Quay](https://quay.io/repository/cdis/gen3-spark/build/b67b1172-c15c-43dc-ba2d-a6067e542f13) build:
```
Package 'openjdk-8-jdk-headless' has no installation candidate
```
**Cause:** `python:2-slim` have been updated from Stretch to Buster.

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
